### PR TITLE
Fix Linux bunyan exec

### DIFF
--- a/edit
+++ b/edit
@@ -12,5 +12,10 @@ export NODE_ENV=production
 export TUTORIAL_EDIT=1
 export NODE_PRESERVE_SYMLINKS=1
 
+# Use a local bunyan if no other is found in the current environment
+if ! [ -x "$(command -v bunyan)" ]; then
+  export PATH="$PATH:./node_modules/bunyan/bin"
+fi
+
 npm --silent run -- gulp edit | bunyan -o short -l debug
 


### PR DESCRIPTION
I see no reasons to assume that `npm --silent run -- gulp edit | bunyan -o short -l debug` takes `PATH` with `./node_modules/.bin` or `bunyan` has been installed globally.

I don't use `bunyan` in global scope and I'm using nvm environments. Therefore `| bunyan` is not found for me.

```sh
$> ./edit ru
< ./edit: line 15: bunyan: command not found
```

I assume that users can use their bunyan's environment. Well let's not disturb them.

Please consider my PR for fix this issue.