### PR TITLE
fix page navigation buttons overlap

### DIFF
--- a/modules/styles/blocks/page/page.styl
+++ b/modules/styles/blocks/page/page.styl
@@ -117,7 +117,7 @@
             transform translateX(sidebar_width)
 
     &__nav_next
-        left 0
+        right 0
         transition top animation_duration
 
     &__nav_next &__nav-text::before


### PR DESCRIPTION
   ` &__nav_next
        right 0  `
will cause page navigation buttons to overlap
