### PR TITLE
[Bug Report] local server page next button css styling broken (#89)

### DIFF
--- a/modules/styles/blocks/page/page.styl
+++ b/modules/styles/blocks/page/page.styl
@@ -117,7 +117,7 @@
             transform translateX(sidebar_width)
 
     &__nav_next
-        left 0
+        right 0
         transition top animation_duration
 
     &__nav_next &__nav-text::before


### PR DESCRIPTION
**[issue link]** https://github.com/javascript-tutorial/server/issues/89

### Edit before
![image](https://user-images.githubusercontent.com/104605709/192533666-6ceaa746-a205-4567-b9b7-b4af9ec9b71d.png)

### Fix
The location of the file is <code>server/modules/styles/blocks/page/page.styl</code>
```css
/* edit before */
&__nav_next
    left 0
    transition top animation_duration
```
```css
/* edit after */
&__nav_next
    right 0
    transition top animation_duration
``` 

### Edit after
![image](https://user-images.githubusercontent.com/104605709/192533996-741baf93-68a2-4dd3-8e43-c966d74b4010.png)